### PR TITLE
Refactor validation error handling for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ const app = express();
 app.use(express.json());
 
 const wrappedHandler = testAuthBearerWrapper(async (params) => {
-  if (params.type === "ok") {
+  if (params.kind === "ok") {
     // Here you can access validated and typed parameters
     const { query, path, headers, body } = params.value;
     // ...
@@ -832,9 +832,9 @@ See [./examples](./examples) directory for more usage examples.
 
 The handler you provide to the wrapper receives a single argument:
 
-- For valid requests: `{ type: "ok", value: { query, path, headers, body, ... }
+- For valid requests: `{ kind: "ok", value: { query, path, headers, body, ... }
 }`
-- For validation errors: `{ type: "query_error" | "body_error" | ... , error:
+- For validation errors: `{ kind: "query_error" | "body_error" | ... , error:
 ZodError }`
 
 It must return an object with `{ status, contentType, data }`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -171,7 +171,7 @@ Generated server wrappers expect handlers that follow this pattern:
 
 ```typescript
 const handler: getPetByIdHandler = async (params) => {
-  if (params.type !== "ok") {
+  if (params.kind !== "ok") {
     // Handle validation errors
     return { status: 400, contentType: "", data: void 0 };
   }
@@ -271,7 +271,7 @@ Each operation generates:
 
 ```typescript
 const handler: operationHandler = async (params) => {
-  if (params.type === "query_error") {
+  if (params.kind === "query_error") {
     // Handle query parameter validation errors
     console.error("Query validation failed:", params.error);
     return {
@@ -281,7 +281,7 @@ const handler: operationHandler = async (params) => {
     };
   }
 
-  if (params.type === "path_error") {
+  if (params.kind === "path_error") {
     // Handle path parameter validation errors
     return {
       status: 400,
@@ -299,7 +299,7 @@ const handler: operationHandler = async (params) => {
 
 ```typescript
 const getPetByIdHandler: getPetByIdHandler = async (params) => {
-  if (params.type !== "ok") {
+  if (params.kind !== "ok") {
     return { status: 400, contentType: "", data: void 0 };
   }
 

--- a/examples/src/express-server-example.ts
+++ b/examples/src/express-server-example.ts
@@ -63,7 +63,7 @@ const mockInventory = {
 
 /* Implementation of findPetsByStatus handler */
 const findPetsByStatusHandler: findPetsByStatusHandler = async (params) => {
-  if (params.type !== "ok") {
+  if (params.kind !== "ok") {
     /* Handle validation errors */
     console.error("Validation error in findPetsByStatus:", params);
     return {
@@ -86,7 +86,7 @@ const findPetsByStatusHandler: findPetsByStatusHandler = async (params) => {
 
 /* Implementation of getPetById handler */
 const getPetByIdHandler: getPetByIdHandler = async (params) => {
-  if (params.type !== "ok") {
+  if (params.kind !== "ok") {
     /* Handle validation errors */
     console.error("Validation error in getPetById:", params);
     return {
@@ -117,7 +117,7 @@ const getPetByIdHandler: getPetByIdHandler = async (params) => {
 /* We disable type checking to allow emitting an unexpected response */
 /* @ts-ignore */
 const getInventoryHandler: getInventoryHandler = async (params) => {
-  if (params.type !== "ok") {
+  if (params.kind !== "ok") {
     /* Handle validation errors */
     console.error("Validation error in getInventory:", params);
     return {

--- a/src/server-generator/templates/server-operation-templates.ts
+++ b/src/server-generator/templates/server-operation-templates.ts
@@ -107,10 +107,10 @@ export function renderServerOperationWrapper(
       : "undefined";
 
   const validationErrorType = `type ${sanitizedId}ValidationError =
-  | { kind: "query_error"; error: z.ZodError }
-  | { kind: "path_error"; error: z.ZodError }
-  | { kind: "headers_error"; error: z.ZodError }
-  | { kind: "body_error"; error: z.ZodError };`;
+  | { kind: "query_error"; error: z.ZodError; success: false }
+  | { kind: "path_error"; error: z.ZodError; success: false }
+  | { kind: "headers_error"; error: z.ZodError; success: false }
+  | { kind: "body_error"; error: z.ZodError; success: false };`;
 
   const parsedParamsType = `type ${sanitizedId}ParsedParams = {
   query: ${sanitizedId}Query;
@@ -120,7 +120,7 @@ export function renderServerOperationWrapper(
 };`;
 
   const handlerType = `export type ${sanitizedId}Handler = (
-  params: { kind: "ok"; value: ${sanitizedId}ParsedParams } | ${sanitizedId}ValidationError,
+  params: { success: true; value: ${sanitizedId}ParsedParams } | ${sanitizedId}ValidationError,
 ) => Promise<${responseType}>;`;
 
   const wrapperFunction = `export function ${functionName}(
@@ -189,13 +189,13 @@ function renderValidationLogic(
     ? `z.infer<(typeof ${requestMapTypeName})["application/json"]>`
     : "undefined";
   const shared = `  const queryParse = ${sanitizedId}QuerySchema.safeParse(req.query);
-  if (!queryParse.success) return handler({ kind: "query_error", error: queryParse.error });
+  if (!queryParse.success) return handler({ kind: "query_error", error: queryParse.error, success: false });
 
   const pathParse = ${sanitizedId}PathSchema.safeParse(req.path);
-  if (!pathParse.success) return handler({ kind: "path_error", error: pathParse.error });
+  if (!pathParse.success) return handler({ kind: "path_error", error: pathParse.error, success: false });
 
   const headersParse = ${sanitizedId}HeadersSchema.safeParse(req.headers);
-  if (!headersParse.success) return handler({ kind: "headers_error", error: headersParse.error });`;
+  if (!headersParse.success) return handler({ kind: "headers_error", error: headersParse.error, success: false });`;
 
   const bodyLogic = requestMapTypeName
     ? `
@@ -204,12 +204,12 @@ function renderValidationLogic(
     const schema = ${requestMapTypeName}[req.contentType];
     if (schema) {
       const bodyParse = schema.strict().safeParse(req.body);
-      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error });
+      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
       parsedBody = bodyParse.data as ${bodyType};
     } else {
       /* Unknown content-type fallback: accept any */
       const bodyParse = z.any().safeParse(req.body);
-      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error });
+      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
       parsedBody = bodyParse.data as ${bodyType};
     }
   }`
@@ -218,7 +218,7 @@ function renderValidationLogic(
   let parsedBody: unknown | undefined = undefined;
   if (req.body !== undefined) {
     const bodyParse = z.any().safeParse(req.body);
-    if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error });
+    if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
     parsedBody = bodyParse.data as unknown;
   }`
       : `
@@ -226,7 +226,7 @@ function renderValidationLogic(
 
   const tail = `
   return handler({
-    kind: "ok",
+    success: true,
     value: {
       query: queryParse.data,
       path: pathParse.data,

--- a/tests/integrations/server-generator/strict-validation-behavior.test.ts
+++ b/tests/integrations/server-generator/strict-validation-behavior.test.ts
@@ -12,13 +12,17 @@ describe("Strict validation behavior", () => {
     let actualError: any = null;
 
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         return {
           status: 200,
           contentType: "application/json",
           data: mockData.newModel(),
         };
-      } else if (params.kind === "body_error") {
+      } else if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "body_error"
+      ) {
         validationErrorReceived = true;
         actualError = params.error;
         return {
@@ -28,7 +32,9 @@ describe("Strict validation behavior", () => {
         };
       }
 
-      throw new Error(`Unexpected validation error: ${params.kind}`);
+      throw new Error(
+        `Unexpected validation error: ${"success" in params && !params.success ? params.kind : "unknown"}`,
+      );
     };
 
     const app = setupTestRoute(
@@ -61,7 +67,7 @@ describe("Strict validation behavior", () => {
 
   it("should accept request body without extra properties", async () => {
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         expect(params.value.body).toEqual({
           id: "test-123",
           name: "Test Object",
@@ -73,7 +79,9 @@ describe("Strict validation behavior", () => {
         };
       }
 
-      throw new Error(`Unexpected validation error: ${params.kind}`);
+      throw new Error(
+        `Unexpected validation error: ${"success" in params && !params.success ? params.kind : "unknown"}`,
+      );
     };
 
     const app = setupTestRoute(

--- a/tests/integrations/server-generator/strict-validation-behavior.test.ts
+++ b/tests/integrations/server-generator/strict-validation-behavior.test.ts
@@ -12,13 +12,13 @@ describe("Strict validation behavior", () => {
     let actualError: any = null;
 
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         return {
           status: 200,
           contentType: "application/json",
           data: mockData.newModel(),
         };
-      } else if (params.type === "body_error") {
+      } else if (params.kind === "body_error") {
         validationErrorReceived = true;
         actualError = params.error;
         return {
@@ -28,7 +28,7 @@ describe("Strict validation behavior", () => {
         };
       }
 
-      throw new Error(`Unexpected validation error: ${params.type}`);
+      throw new Error(`Unexpected validation error: ${params.kind}`);
     };
 
     const app = setupTestRoute(
@@ -61,7 +61,7 @@ describe("Strict validation behavior", () => {
 
   it("should accept request body without extra properties", async () => {
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         expect(params.value.body).toEqual({
           id: "test-123",
           name: "Test Object",
@@ -73,7 +73,7 @@ describe("Strict validation behavior", () => {
         };
       }
 
-      throw new Error(`Unexpected validation error: ${params.type}`);
+      throw new Error(`Unexpected validation error: ${params.kind}`);
     };
 
     const app = setupTestRoute(

--- a/tests/integrations/server-generator/testAuthBearer.test.ts
+++ b/tests/integrations/server-generator/testAuthBearer.test.ts
@@ -11,7 +11,7 @@ describe("testAuthBearer operation integration tests", () => {
   it("should return 200 with valid Person when all required parameters are provided", async () => {
     // Arrange: Setup the Express route with the generated wrapper
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         // Validate that required query parameters are present
         expect(params.value.query.qr).toBeDefined();
         expect(params.value.query.qr).toBe("test-required");
@@ -61,7 +61,7 @@ describe("testAuthBearer operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.type === "query_error") {
+      if (params.kind === "query_error") {
         validationErrorReceived = true;
         // Verify the validation error structure
         expect(params.error.issues).toBeDefined();
@@ -116,7 +116,7 @@ describe("testAuthBearer operation integration tests", () => {
     let cursorValidationFailed = false;
 
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.type === "query_error") {
+      if (params.kind === "query_error") {
         cursorValidationFailed = true;
         // Check that cursor validation failed
         const cursorError = params.error.issues.find((issue) =>
@@ -170,7 +170,7 @@ describe("testAuthBearer operation integration tests", () => {
     // Arrange
     // Note: After fixing the bug, optional parameters are now properly optional
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         // Only qr should be required according to OpenAPI spec
         expect(params.value.query.qr).toBe("required-only");
         // Optional parameters should be undefined when not provided

--- a/tests/integrations/server-generator/testAuthBearer.test.ts
+++ b/tests/integrations/server-generator/testAuthBearer.test.ts
@@ -11,7 +11,7 @@ describe("testAuthBearer operation integration tests", () => {
   it("should return 200 with valid Person when all required parameters are provided", async () => {
     // Arrange: Setup the Express route with the generated wrapper
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         // Validate that required query parameters are present
         expect(params.value.query.qr).toBeDefined();
         expect(params.value.query.qr).toBe("test-required");
@@ -61,7 +61,11 @@ describe("testAuthBearer operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.kind === "query_error") {
+      if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "query_error"
+      ) {
         validationErrorReceived = true;
         // Verify the validation error structure
         expect(params.error.issues).toBeDefined();
@@ -116,7 +120,11 @@ describe("testAuthBearer operation integration tests", () => {
     let cursorValidationFailed = false;
 
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.kind === "query_error") {
+      if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "query_error"
+      ) {
         cursorValidationFailed = true;
         // Check that cursor validation failed
         const cursorError = params.error.issues.find((issue) =>
@@ -170,7 +178,7 @@ describe("testAuthBearer operation integration tests", () => {
     // Arrange
     // Note: After fixing the bug, optional parameters are now properly optional
     const handler: testAuthBearerHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         // Only qr should be required according to OpenAPI spec
         expect(params.value.query.qr).toBe("required-only");
         // Optional parameters should be undefined when not provided

--- a/tests/integrations/server-generator/testAuthBearerHttp.test.ts
+++ b/tests/integrations/server-generator/testAuthBearerHttp.test.ts
@@ -10,7 +10,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 503 with TestAuthBearerHttp503Response", async () => {
     // Arrange: Setup handler to return 503 status
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         expect(params.value.query.qr).toBe("test-503");
 
         return {
@@ -52,7 +52,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 504 with ProblemDetails (application/problem+json)", async () => {
     // Arrange: Setup handler to return 504 status with ProblemDetails
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         expect(params.value.query.qr).toBe("test-504");
 
         return {
@@ -98,7 +98,11 @@ describe("testAuthBearerHttp operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.kind === "query_error") {
+      if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "query_error"
+      ) {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();
 
@@ -152,7 +156,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should validate different content types properly", async () => {
     // Arrange: Test both content types work
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         const contentType = params.value.query.qr;
 
         if (contentType === "json") {

--- a/tests/integrations/server-generator/testAuthBearerHttp.test.ts
+++ b/tests/integrations/server-generator/testAuthBearerHttp.test.ts
@@ -10,7 +10,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 503 with TestAuthBearerHttp503Response", async () => {
     // Arrange: Setup handler to return 503 status
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         expect(params.value.query.qr).toBe("test-503");
 
         return {
@@ -52,7 +52,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should return 504 with ProblemDetails (application/problem+json)", async () => {
     // Arrange: Setup handler to return 504 status with ProblemDetails
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         expect(params.value.query.qr).toBe("test-504");
 
         return {
@@ -98,7 +98,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.type === "query_error") {
+      if (params.kind === "query_error") {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();
 
@@ -152,7 +152,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
   it("should validate different content types properly", async () => {
     // Arrange: Test both content types work
     const handler: testAuthBearerHttpHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         const contentType = params.value.query.qr;
 
         if (contentType === "json") {

--- a/tests/integrations/server-generator/testMultiContentTypes.test.ts
+++ b/tests/integrations/server-generator/testMultiContentTypes.test.ts
@@ -10,7 +10,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle JSON content type request and response", async () => {
     // Arrange: Handler that accepts JSON and returns JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         expect(params.value.body).toBeDefined();
         expect(params.value.body).toMatchObject({
           id: "test-123",
@@ -55,7 +55,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle custom JSON content type response", async () => {
     // Arrange: Handler that returns custom vnd JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         return {
           status: 200,
           contentType: "application/vnd.custom+json",
@@ -99,7 +99,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle form-urlencoded content type", async () => {
     // Arrange: Handler that accepts form data
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         expect(params.value.body).toBeDefined();
         // Form-encoded data might be parsed differently
 
@@ -143,7 +143,7 @@ describe("testMultiContentTypes operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "body_error") {
+      if (params.kind === "body_error") {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();
 
@@ -196,7 +196,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle unknown content types gracefully", async () => {
     // Arrange: Handler that accepts any content type
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         // Should still receive the body even with unknown content type
         // Body might be undefined for unknown content types, which is acceptable
 
@@ -208,7 +208,7 @@ describe("testMultiContentTypes operation integration tests", () => {
             name: "Unknown Content Type",
           },
         };
-      } else if (params.type === "body_error") {
+      } else if (params.kind === "body_error") {
         // If there's a body validation error with unknown content type, that's also acceptable
         return {
           status: 200,

--- a/tests/integrations/server-generator/testMultiContentTypes.test.ts
+++ b/tests/integrations/server-generator/testMultiContentTypes.test.ts
@@ -10,7 +10,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle JSON content type request and response", async () => {
     // Arrange: Handler that accepts JSON and returns JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         expect(params.value.body).toBeDefined();
         expect(params.value.body).toMatchObject({
           id: "test-123",
@@ -55,7 +55,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle custom JSON content type response", async () => {
     // Arrange: Handler that returns custom vnd JSON
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         return {
           status: 200,
           contentType: "application/vnd.custom+json",
@@ -99,7 +99,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle form-urlencoded content type", async () => {
     // Arrange: Handler that accepts form data
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         expect(params.value.body).toBeDefined();
         // Form-encoded data might be parsed differently
 
@@ -143,7 +143,11 @@ describe("testMultiContentTypes operation integration tests", () => {
     let validationErrorReceived = false;
 
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "body_error") {
+      if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "body_error"
+      ) {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();
 
@@ -196,7 +200,7 @@ describe("testMultiContentTypes operation integration tests", () => {
   it("should handle unknown content types gracefully", async () => {
     // Arrange: Handler that accepts any content type
     const handler: testMultiContentTypesHandler = async (params) => {
-      if (params.kind === "ok") {
+      if ("success" in params && params.success) {
         // Should still receive the body even with unknown content type
         // Body might be undefined for unknown content types, which is acceptable
 
@@ -208,7 +212,11 @@ describe("testMultiContentTypes operation integration tests", () => {
             name: "Unknown Content Type",
           },
         };
-      } else if (params.kind === "body_error") {
+      } else if (
+        "success" in params &&
+        !params.success &&
+        params.kind === "body_error"
+      ) {
         // If there's a body validation error with unknown content type, that's also acceptable
         return {
           status: 200,

--- a/tests/integrations/server-generator/testParameterWithDash.test.ts
+++ b/tests/integrations/server-generator/testParameterWithDash.test.ts
@@ -13,7 +13,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
   it("should return 200 with all parameters correctly validated and passed", async () => {
     // Arrange: Setup handler to validate all parameter types
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         // Validate path parameters
         expect(params.value.path.pathParam).toBe("test-path-param");
 
@@ -65,7 +65,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let pathValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.type === "path_error") {
+      if (params.kind === "path_error") {
         pathValidationFailed = true;
         // Check that path validation failed for minimum length
         const pathError = params.error.issues.find((issue) =>
@@ -122,7 +122,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let queryValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.type === "query_error") {
+      if (params.kind === "query_error") {
         queryValidationFailed = true;
         // Check that request-id validation failed for minimum length
         const requestIdError = params.error.issues.find((issue) =>
@@ -179,7 +179,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let headerValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.type === "headers_error") {
+      if (params.kind === "headers_error") {
         headerValidationFailed = true;
         // Check that header validation failed
         expect(params.error.issues.length).toBeGreaterThan(0);
@@ -231,7 +231,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     // (foo-bar -> fooBar, path-param -> pathParam, etc.)
     const handler: testParameterWithDashHandler = async (params) => {
       console.log(params);
-      if (params.type === "ok") {
+      if (params.kind === "ok") {
         // The generated wrapper should transform kebab-case to camelCase
         expect(params.value.query).toHaveProperty("fooBar");
         expect(params.value.query).toHaveProperty("requestId");

--- a/tests/server-generator-comprehensive.test.ts
+++ b/tests/server-generator-comprehensive.test.ts
@@ -86,7 +86,7 @@ describe("server-generator comprehensive validation", () => {
     expect(result.wrapperCode).toContain("bodyParse.success");
 
     /* Verify success handler call */
-    expect(result.wrapperCode).toContain('kind: "ok"');
+    expect(result.wrapperCode).toContain("success: true");
     expect(result.wrapperCode).toContain("value: {");
     expect(result.wrapperCode).toContain("query: queryParse.data");
     expect(result.wrapperCode).toContain("path: pathParse.data");
@@ -136,7 +136,7 @@ describe("server-generator comprehensive validation", () => {
     /* Should include handler type with discriminated union */
     expect(result.wrapperCode).toContain("testOperationHandler");
     expect(result.wrapperCode).toContain(
-      '{ kind: "ok"; value: testOperationParsedParams }',
+      "{ success: true; value: testOperationParsedParams }",
     );
     expect(result.wrapperCode).toContain("testOperationValidationError");
   });

--- a/tests/server-generator-comprehensive.test.ts
+++ b/tests/server-generator-comprehensive.test.ts
@@ -86,7 +86,7 @@ describe("server-generator comprehensive validation", () => {
     expect(result.wrapperCode).toContain("bodyParse.success");
 
     /* Verify success handler call */
-    expect(result.wrapperCode).toContain('type: "ok"');
+    expect(result.wrapperCode).toContain('kind: "ok"');
     expect(result.wrapperCode).toContain("value: {");
     expect(result.wrapperCode).toContain("query: queryParse.data");
     expect(result.wrapperCode).toContain("path: pathParse.data");
@@ -122,10 +122,10 @@ describe("server-generator comprehensive validation", () => {
 
     /* Should include validation error discriminated union */
     expect(result.wrapperCode).toContain("testOperationValidationError");
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*type:\s*"query_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*type:\s*"path_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*type:\s*"headers_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*type:\s*"body_error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"query_error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"path_error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"headers_error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"body_error"/);
 
     /* Should include parsed params type */
     expect(result.wrapperCode).toContain("testOperationParsedParams");
@@ -136,7 +136,7 @@ describe("server-generator comprehensive validation", () => {
     /* Should include handler type with discriminated union */
     expect(result.wrapperCode).toContain("testOperationHandler");
     expect(result.wrapperCode).toContain(
-      '{ type: "ok"; value: testOperationParsedParams }',
+      '{ kind: "ok"; value: testOperationParsedParams }',
     );
     expect(result.wrapperCode).toContain("testOperationValidationError");
   });

--- a/tests/server-generator-exact-match.test.ts
+++ b/tests/server-generator-exact-match.test.ts
@@ -76,21 +76,21 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify error handling with correct error types */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ type: "query_error", error: queryParse\.error \}\)/,
+      /return handler\(\{ kind: "query_error", error: queryParse\.error \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ type: "path_error", error: pathParse\.error \}\)/,
+      /return handler\(\{ kind: "path_error", error: pathParse\.error \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ type: "headers_error", error: headersParse\.error \}\)/,
+      /return handler\(\{ kind: "headers_error", error: headersParse\.error \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ type: "body_error", error: bodyParse\.error \}\)/,
+      /return handler\(\{ kind: "body_error", error: bodyParse\.error \}\)/,
     );
 
     /* Verify success handler call with all parameters */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{\s*type: "ok",\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
+      /return handler\(\{\s*kind: "ok",\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
     );
 
     /* Verify discriminated union types are correctly defined */
@@ -108,7 +108,7 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify handler type includes both success and error cases */
     expect(result.wrapperCode).toMatch(
-      /petFindByStatusHandler = \(\s*params: \{ type: "ok"; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
+      /petFindByStatusHandler = \(\s*params: \{ kind: "ok"; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
     );
   });
 

--- a/tests/server-generator-exact-match.test.ts
+++ b/tests/server-generator-exact-match.test.ts
@@ -76,21 +76,21 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify error handling with correct error types */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "query_error", error: queryParse\.error \}\)/,
+      /return handler\(\{ kind: "query_error", error: queryParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "path_error", error: pathParse\.error \}\)/,
+      /return handler\(\{ kind: "path_error", error: pathParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "headers_error", error: headersParse\.error \}\)/,
+      /return handler\(\{ kind: "headers_error", error: headersParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "body_error", error: bodyParse\.error \}\)/,
+      /return handler\(\{ kind: "body_error", error: bodyParse\.error, success: false \}\)/,
     );
 
     /* Verify success handler call with all parameters */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{\s*kind: "ok",\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
+      /return handler\(\{\s*success: true,\s*value: \{\s*query: queryParse\.data,\s*path: pathParse\.data,\s*headers: headersParse\.data,\s*body: parsedBody\s*\},?\s*\}\)/,
     );
 
     /* Verify discriminated union types are correctly defined */
@@ -108,7 +108,7 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify handler type includes both success and error cases */
     expect(result.wrapperCode).toMatch(
-      /petFindByStatusHandler = \(\s*params: \{ kind: "ok"; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
+      /petFindByStatusHandler = \(\s*params: \{ success: true; value: petFindByStatusParsedParams \} \| petFindByStatusValidationError,?\s*\) => Promise<petFindByStatusResponse>/,
     );
   });
 

--- a/tests/server-generator.test.ts
+++ b/tests/server-generator.test.ts
@@ -50,7 +50,7 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain('kind: "path_error"');
     expect(result.wrapperCode).toContain('kind: "headers_error"');
     expect(result.wrapperCode).toContain('kind: "body_error"');
-    expect(result.wrapperCode).toContain('kind: "ok"');
+    expect(result.wrapperCode).toContain("success: true");
   });
 
   it("should use strict validation for server input types (query, path, headers)", () => {

--- a/tests/server-generator.test.ts
+++ b/tests/server-generator.test.ts
@@ -46,11 +46,11 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain("testSimpleQueryQuerySchema");
     expect(result.wrapperCode).toContain('"query1": z.string()');
     expect(result.wrapperCode).toContain('"query2": z.string()');
-    expect(result.wrapperCode).toContain('type: "query_error"');
-    expect(result.wrapperCode).toContain('type: "path_error"');
-    expect(result.wrapperCode).toContain('type: "headers_error"');
-    expect(result.wrapperCode).toContain('type: "body_error"');
-    expect(result.wrapperCode).toContain('type: "ok"');
+    expect(result.wrapperCode).toContain('kind: "query_error"');
+    expect(result.wrapperCode).toContain('kind: "path_error"');
+    expect(result.wrapperCode).toContain('kind: "headers_error"');
+    expect(result.wrapperCode).toContain('kind: "body_error"');
+    expect(result.wrapperCode).toContain('kind: "ok"');
   });
 
   it("should use strict validation for server input types (query, path, headers)", () => {


### PR DESCRIPTION
Update validation error handling to use 'kind' instead of 'type' and introduce a 'success' flag for improved clarity across the codebase.