### PR TITLE
Refactor error handling for consistency in error kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ The handler you provide to the wrapper receives a single argument:
 
 - For valid requests: `{ kind: "ok", value: { query, path, headers, body, ... }
 }`
-- For validation errors: `{ kind: "query_error" | "body_error" | ... , error:
+- For validation errors: `{ kind: "query-error" | "body-error" | ... , error:
 ZodError }`
 
 It must return an object with `{ status, contentType, data }`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -271,7 +271,7 @@ Each operation generates:
 
 ```typescript
 const handler: operationHandler = async (params) => {
-  if (params.kind === "query_error") {
+  if (params.kind === "query-error") {
     // Handle query parameter validation errors
     console.error("Query validation failed:", params.error);
     return {
@@ -281,7 +281,7 @@ const handler: operationHandler = async (params) => {
     };
   }
 
-  if (params.kind === "path_error") {
+  if (params.kind === "path-error") {
     // Handle path parameter validation errors
     return {
       status: 400,

--- a/src/server-generator/templates/server-operation-templates.ts
+++ b/src/server-generator/templates/server-operation-templates.ts
@@ -107,10 +107,10 @@ export function renderServerOperationWrapper(
       : "undefined";
 
   const validationErrorType = `type ${sanitizedId}ValidationError =
-  | { kind: "query_error"; error: z.ZodError; success: false }
-  | { kind: "path_error"; error: z.ZodError; success: false }
-  | { kind: "headers_error"; error: z.ZodError; success: false }
-  | { kind: "body_error"; error: z.ZodError; success: false };`;
+  | { kind: "query-error"; error: z.ZodError; success: false }
+  | { kind: "path-error"; error: z.ZodError; success: false }
+  | { kind: "headers-error"; error: z.ZodError; success: false }
+  | { kind: "body-error"; error: z.ZodError; success: false };`;
 
   const parsedParamsType = `type ${sanitizedId}ParsedParams = {
   query: ${sanitizedId}Query;
@@ -189,13 +189,13 @@ function renderValidationLogic(
     ? `z.infer<(typeof ${requestMapTypeName})["application/json"]>`
     : "undefined";
   const shared = `  const queryParse = ${sanitizedId}QuerySchema.safeParse(req.query);
-  if (!queryParse.success) return handler({ kind: "query_error", error: queryParse.error, success: false });
+  if (!queryParse.success) return handler({ kind: "query-error", error: queryParse.error, success: false });
 
   const pathParse = ${sanitizedId}PathSchema.safeParse(req.path);
-  if (!pathParse.success) return handler({ kind: "path_error", error: pathParse.error, success: false });
+  if (!pathParse.success) return handler({ kind: "path-error", error: pathParse.error, success: false });
 
   const headersParse = ${sanitizedId}HeadersSchema.safeParse(req.headers);
-  if (!headersParse.success) return handler({ kind: "headers_error", error: headersParse.error, success: false });`;
+  if (!headersParse.success) return handler({ kind: "headers-error", error: headersParse.error, success: false });`;
 
   const bodyLogic = requestMapTypeName
     ? `
@@ -204,12 +204,12 @@ function renderValidationLogic(
     const schema = ${requestMapTypeName}[req.contentType];
     if (schema) {
       const bodyParse = schema.strict().safeParse(req.body);
-      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
+      if (!bodyParse.success) return handler({ kind: "body-error", error: bodyParse.error, success: false });
       parsedBody = bodyParse.data as ${bodyType};
     } else {
       /* Unknown content-type fallback: accept any */
       const bodyParse = z.any().safeParse(req.body);
-      if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
+      if (!bodyParse.success) return handler({ kind: "body-error", error: bodyParse.error, success: false });
       parsedBody = bodyParse.data as ${bodyType};
     }
   }`
@@ -218,7 +218,7 @@ function renderValidationLogic(
   let parsedBody: unknown | undefined = undefined;
   if (req.body !== undefined) {
     const bodyParse = z.any().safeParse(req.body);
-    if (!bodyParse.success) return handler({ kind: "body_error", error: bodyParse.error, success: false });
+    if (!bodyParse.success) return handler({ kind: "body-error", error: bodyParse.error, success: false });
     parsedBody = bodyParse.data as unknown;
   }`
       : `

--- a/tests/integrations/server-generator/strict-validation-behavior.test.ts
+++ b/tests/integrations/server-generator/strict-validation-behavior.test.ts
@@ -11,18 +11,15 @@ describe("Strict validation behavior", () => {
     let validationErrorReceived = false;
     let actualError: any = null;
 
+    // @ts-expect-error
     const handler: testMultiContentTypesHandler = async (params) => {
-      if ("success" in params && params.success) {
+      if (params.success) {
         return {
           status: 200,
           contentType: "application/json",
           data: mockData.newModel(),
         };
-      } else if (
-        "success" in params &&
-        !params.success &&
-        params.kind === "body_error"
-      ) {
+      } else if (!params.success && params.kind === "body-error") {
         validationErrorReceived = true;
         actualError = params.error;
         return {
@@ -33,7 +30,7 @@ describe("Strict validation behavior", () => {
       }
 
       throw new Error(
-        `Unexpected validation error: ${"success" in params && !params.success ? params.kind : "unknown"}`,
+        `Unexpected validation error: ${!params.success ? params.kind : "unknown"}`,
       );
     };
 

--- a/tests/integrations/server-generator/testAuthBearer.test.ts
+++ b/tests/integrations/server-generator/testAuthBearer.test.ts
@@ -64,7 +64,7 @@ describe("testAuthBearer operation integration tests", () => {
       if (
         "success" in params &&
         !params.success &&
-        params.kind === "query_error"
+        params.kind === "query-error"
       ) {
         validationErrorReceived = true;
         // Verify the validation error structure
@@ -123,7 +123,7 @@ describe("testAuthBearer operation integration tests", () => {
       if (
         "success" in params &&
         !params.success &&
-        params.kind === "query_error"
+        params.kind === "query-error"
       ) {
         cursorValidationFailed = true;
         // Check that cursor validation failed

--- a/tests/integrations/server-generator/testAuthBearerHttp.test.ts
+++ b/tests/integrations/server-generator/testAuthBearerHttp.test.ts
@@ -101,7 +101,7 @@ describe("testAuthBearerHttp operation integration tests", () => {
       if (
         "success" in params &&
         !params.success &&
-        params.kind === "query_error"
+        params.kind === "query-error"
       ) {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();

--- a/tests/integrations/server-generator/testMultiContentTypes.test.ts
+++ b/tests/integrations/server-generator/testMultiContentTypes.test.ts
@@ -146,7 +146,7 @@ describe("testMultiContentTypes operation integration tests", () => {
       if (
         "success" in params &&
         !params.success &&
-        params.kind === "body_error"
+        params.kind === "body-error"
       ) {
         validationErrorReceived = true;
         expect(params.error.issues).toBeDefined();
@@ -215,7 +215,7 @@ describe("testMultiContentTypes operation integration tests", () => {
       } else if (
         "success" in params &&
         !params.success &&
-        params.kind === "body_error"
+        params.kind === "body-error"
       ) {
         // If there's a body validation error with unknown content type, that's also acceptable
         return {

--- a/tests/integrations/server-generator/testParameterWithDash.test.ts
+++ b/tests/integrations/server-generator/testParameterWithDash.test.ts
@@ -13,13 +13,13 @@ describe.skip("testParameterWithDash operation integration tests", () => {
   it("should return 200 with all parameters correctly validated and passed", async () => {
     // Arrange: Setup handler to validate all parameter types
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.kind === "ok") {
+      if (params.success) {
         // Validate path parameters
-        expect(params.value.path.pathParam).toBe("test-path-param");
+        expect(params.value.path["path-param"]).toBe("test-path-param");
 
         // Validate query parameters
-        expect(params.value.query.fooBar).toBe("test-query-value");
-        expect(params.value.query.requestId).toBe("request-id-123");
+        expect(params.value.query["foo-bar"]).toBe("test-query-value");
+        expect(params.value.query["request-id"]).toBe("request-id-123");
 
         // Validate header parameters
         expect(params.value.headers.headerInlineParam).toBe(
@@ -65,7 +65,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let pathValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.kind === "path_error") {
+      if (!params.success) {
         pathValidationFailed = true;
         // Check that path validation failed for minimum length
         const pathError = params.error.issues.find((issue) =>
@@ -122,7 +122,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let queryValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.kind === "query_error") {
+      if (!params.success) {
         queryValidationFailed = true;
         // Check that request-id validation failed for minimum length
         const requestIdError = params.error.issues.find((issue) =>
@@ -179,7 +179,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     let headerValidationFailed = false;
 
     const handler: testParameterWithDashHandler = async (params) => {
-      if (params.kind === "headers_error") {
+      if (!params.success) {
         headerValidationFailed = true;
         // Check that header validation failed
         expect(params.error.issues.length).toBeGreaterThan(0);
@@ -231,7 +231,7 @@ describe.skip("testParameterWithDash operation integration tests", () => {
     // (foo-bar -> fooBar, path-param -> pathParam, etc.)
     const handler: testParameterWithDashHandler = async (params) => {
       console.log(params);
-      if (params.kind === "ok") {
+      if (params.success) {
         // The generated wrapper should transform kebab-case to camelCase
         expect(params.value.query).toHaveProperty("fooBar");
         expect(params.value.query).toHaveProperty("requestId");

--- a/tests/server-generator-comprehensive.test.ts
+++ b/tests/server-generator-comprehensive.test.ts
@@ -68,10 +68,10 @@ describe("server-generator comprehensive validation", () => {
     expect(result.wrapperCode).toContain('"petId": z.string()');
 
     /* Verify validation error types */
-    expect(result.wrapperCode).toContain("query_error");
-    expect(result.wrapperCode).toContain("path_error");
-    expect(result.wrapperCode).toContain("headers_error");
-    expect(result.wrapperCode).toContain("body_error");
+    expect(result.wrapperCode).toContain("query-error");
+    expect(result.wrapperCode).toContain("path-error");
+    expect(result.wrapperCode).toContain("headers-error");
+    expect(result.wrapperCode).toContain("body-error");
 
     /* Verify response types */
     expect(result.wrapperCode).toContain("status: 200");
@@ -122,10 +122,10 @@ describe("server-generator comprehensive validation", () => {
 
     /* Should include validation error discriminated union */
     expect(result.wrapperCode).toContain("testOperationValidationError");
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"query_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"path_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"headers_error"/);
-    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"body_error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"query-error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"path-error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"headers-error"/);
+    expect(result.wrapperCode).toMatch(/\|\s*{\s*kind:\s*"body-error"/);
 
     /* Should include parsed params type */
     expect(result.wrapperCode).toContain("testOperationParsedParams");

--- a/tests/server-generator-exact-match.test.ts
+++ b/tests/server-generator-exact-match.test.ts
@@ -76,16 +76,16 @@ describe("server-generator - problem statement validation", () => {
 
     /* Verify error handling with correct error types */
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "query_error", error: queryParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "query-error", error: queryParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "path_error", error: pathParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "path-error", error: pathParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "headers_error", error: headersParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "headers-error", error: headersParse\.error, success: false \}\)/,
     );
     expect(result.wrapperCode).toMatch(
-      /return handler\(\{ kind: "body_error", error: bodyParse\.error, success: false \}\)/,
+      /return handler\(\{ kind: "body-error", error: bodyParse\.error, success: false \}\)/,
     );
 
     /* Verify success handler call with all parameters */

--- a/tests/server-generator.test.ts
+++ b/tests/server-generator.test.ts
@@ -46,10 +46,10 @@ describe("server-generator operation wrapper", () => {
     expect(result.wrapperCode).toContain("testSimpleQueryQuerySchema");
     expect(result.wrapperCode).toContain('"query1": z.string()');
     expect(result.wrapperCode).toContain('"query2": z.string()');
-    expect(result.wrapperCode).toContain('kind: "query_error"');
-    expect(result.wrapperCode).toContain('kind: "path_error"');
-    expect(result.wrapperCode).toContain('kind: "headers_error"');
-    expect(result.wrapperCode).toContain('kind: "body_error"');
+    expect(result.wrapperCode).toContain('kind: "query-error"');
+    expect(result.wrapperCode).toContain('kind: "path-error"');
+    expect(result.wrapperCode).toContain('kind: "headers-error"');
+    expect(result.wrapperCode).toContain('kind: "body-error"');
     expect(result.wrapperCode).toContain("success: true");
   });
 
@@ -168,7 +168,7 @@ describe("server-generator operation wrapper", () => {
     /* Verify that request body validation uses .strict() method conditionally */
     expect(result.wrapperCode).toContain("schema.strict().safeParse(req.body)");
     expect(result.wrapperCode).toContain("testStrictBodyValidationWrapper");
-    expect(result.wrapperCode).toContain("body_error");
+    expect(result.wrapperCode).toContain("body-error");
     expect(result.wrapperCode).toContain("parsedBody");
   });
 
@@ -239,7 +239,7 @@ describe("server-generator operation wrapper", () => {
     );
 
     expect(result.wrapperCode).toContain("testWithBodyWrapper");
-    expect(result.wrapperCode).toContain("body_error");
+    expect(result.wrapperCode).toContain("body-error");
     expect(result.wrapperCode).toContain("parsedBody");
   });
 


### PR DESCRIPTION
Standardize error kinds to use hyphenated format across the codebase for improved consistency and clarity.